### PR TITLE
Remove needless use statement to fix PHP warning

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,7 +9,6 @@
 * file that was distributed with this source code.
 */
 
-use DirectoryIterator;
 use Flarum\Event\PrepareApiAttributes;
 use Flarum\Event\ConfigureLocales;
 use Flarum\Event\ConfigureClientView;


### PR DESCRIPTION
PHP 5.6.14. Getting this warning at the top of every page after enabling the extension:

> Warning: The use statement with non-compound name 'DirectoryIterator' has no effect in /vagrant/extensions/matpompili-imgur-upload/bootstrap.php on line 12

Because bootstrap.php does not have a namespace, importing DirectoryIterator is unnecessary. Removing the `use DirectoryIterator` line fixes the problem.
